### PR TITLE
Nix support

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, base, BinderAnn, containers, mtl, multiset, process
+, stdenv, tasty, tasty-hunit
+# python package needed at test and run time, undeclared in .cabal file
+, paganini 
+}:
+mkDerivation {
+  pname = "paganini-hs";
+  version = "0.2.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    base BinderAnn containers mtl multiset process tasty tasty-hunit
+  ];
+  testHaskellDepends = [
+    base
+    BinderAnn
+    tasty
+    tasty-hunit
+    paganini
+  ];
+  homepage = "https://github.com/maciej-bendkowski/paganini-hs#readme";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,111 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1605370193,
+        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "mach-nix": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs",
+        "pypi-deps-db": "pypi-deps-db"
+      },
+      "locked": {
+        "lastModified": 1608533717,
+        "narHash": "sha256-4WBxnZMCF9vX4oJnw49LvVDPXCOh1Pa/vhmnIJbQi08=",
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "rev": "c4ef8f4a01f8ca8df857f6318fecb6cdbee37d58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "mach-nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1605988311,
+        "narHash": "sha256-PA+kgq46NApOAJlmBNJHs5DwsIrY+jodM0e4g7VtXyY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2247d824fe07f16325596acc7faa286502faffd1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1608122323,
+        "narHash": "sha256-ivxC1U9pUMziQcyvVHAOGi/IwzJ896C6DKbkKLJysoo=",
+        "owner": "NixOs",
+        "repo": "nixpkgs",
+        "rev": "00941cd747e9bc1c3326d1362dbc7e9cfe18cf53",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOs",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pypi-deps-db": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606280641,
+        "narHash": "sha256-sVYIBMtvZgxQQkbxZg/45xw4e7vVh+5SU1kkvUvtnrc=",
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "rev": "63bb8887c8de8e056f5ed77ac6a35c771c0c5d57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DavHau",
+        "repo": "pypi-deps-db",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "mach-nix": "mach-nix",
+        "nixpkgs": "nixpkgs_2"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   inputs.mach-nix.url = "github:DavHau/mach-nix";
 
   outputs = { self, nixpkgs, flake-utils, mach-nix }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
       let
 
         name = "pagnaini-hs";

--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,8 @@
             haskellPackages.haskell-language-server
             haskellPackages.hlint
             haskellPackages.ormolu
-            cabal2nix
+            haskellPackages.cabal2nix
+            paganini-custom
           ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "nix flake support for paganini-hs";
+
+  inputs.nixpkgs.url = "github:NixOs/nixpkgs/nixpkgs-unstable"; 
+  
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.mach-nix.url = "github:DavHau/mach-nix";
+
+  outputs = { self, nixpkgs, flake-utils, mach-nix }:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+      let
+
+        name = "pagnaini-hs";
+        
+        # paganini-hs dependency BinderAnn won't compile with later ghc versions 
+        compiler = "ghc865";  
+         
+        pkgs = import nixpkgs {
+          inherit system;
+          config = {
+            allowUnfree = true;
+            allowBroken = true;
+            allowUnsupportedSystem = true;
+          };
+          # overlays = [] # Add or tweak non-Haskell packages here.
+        };
+
+        mylib = mach-nix.lib.${system}; # adds mkPython, mkPythonShell, etc. 
+
+        paganini-custom = mylib.mkPython {
+          requirements = ''
+            paganini==1.3.3
+            cvxpy>=1.1.7 
+            scs==2.1.1-2 # scs 2.1.2 broken 
+          '';
+        };
+       
+        haskellPackages = pkgs.haskell.packages.${compiler}.override {
+          overrides = self: super: {
+            #"${name}" = self.callCabal2nix name ./. {};
+            "${name}" = self.callPackage ./. { paganini = paganini-custom; };
+            # Override other Haskell packages as needed here.
+          };
+        };
+        
+        devShell = haskellPackages.shellFor {
+          withHoogle = true; # Provides docs, optional. 
+          packages = p: [
+            p."${name}"
+            # Add other Haskell packages below if you just want a Haskell hacking env.
+            # p.lens
+          ]; 
+          buildInputs = with pkgs; [
+            haskellPackages.cabal-install
+            haskellPackages.ghcid
+            haskellPackages.haskell-language-server
+            haskellPackages.hlint
+            haskellPackages.ormolu
+            cabal2nix
+          ];
+        };
+
+        defaultPackage = haskellPackages."${name}";
+        derive = import ./.;
+        
+      in
+        {
+          inherit derive defaultPackage devShell;
+        });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   inputs.mach-nix.url = "github:DavHau/mach-nix";
 
   outputs = { self, nixpkgs, flake-utils, mach-nix }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
 
         name = "pagnaini-hs";


### PR DESCRIPTION
Provide nix support for paganini-hs. Ensures nix can build a paganini python package and make it visible in `nix-shell` or `nix develop` environment. PR is a prerequisite for similar PR for boltzmann-brain.
